### PR TITLE
Correct Memory Barriers and data validation in benchmark

### DIFF
--- a/DisruptorUnity3d/Assets/RingBuffer.cs
+++ b/DisruptorUnity3d/Assets/RingBuffer.cs
@@ -47,13 +47,13 @@ namespace DisruptorUnity3d
         /// <returns>The next available item</returns>
         public T Dequeue()
         {
-            var next = _consumerCursor.ReadFullFence() + 1;
-            while (_producerCursor.ReadFullFence() < next)
+            var next = _consumerCursor.ReadAcquireFence() + 1;
+            while (_producerCursor.ReadAcquireFence() < next) // makes sure we read the data from _entries after we have read the producer cursor
             {
                 Thread.SpinWait(1);
             }
             var result = this[next];
-            _consumerCursor.WriteFullFence(next);
+            _consumerCursor.WriteReleaseFence(next); // makes sure we read the data from _entries before we update the consumer cursor
             return result;
         }
 
@@ -64,9 +64,9 @@ namespace DisruptorUnity3d
         /// <returns>True if successful</returns>
         public bool TryDequeue(out T obj)
         {
-            var next = _consumerCursor.ReadFullFence() + 1;
+            var next = _consumerCursor.ReadAcquireFence() + 1;
 
-            if (_producerCursor.ReadFullFence() < next)
+            if (_producerCursor.ReadAcquireFence() < next)
             {
                 obj = default(T);
                 return false;
@@ -81,19 +81,19 @@ namespace DisruptorUnity3d
         /// <param name="item"></param>
         public void Enqueue(T item)
         {
-            var next = _producerCursor.ReadFullFence() + 1;
+            var next = _producerCursor.ReadAcquireFence() + 1;
 
             long wrapPoint = next - _entries.Length;
-            long min = _consumerCursor.ReadFullFence();
+            long min = _consumerCursor.ReadAcquireFence(); 
 
             while (wrapPoint > min)
             {
-                min = _consumerCursor.ReadFullFence();
+                min = _consumerCursor.ReadAcquireFence();
                 Thread.SpinWait(1);
             }
 
             this[next] = item;
-            _producerCursor.WriteUnfenced(next);
+            _producerCursor.WriteReleaseFence(next); // makes sure we write the data in _entries before we update the producer cursor
         }
 
         /// <summary>

--- a/DisruptorUnity3d/Assets/Test.cs
+++ b/DisruptorUnity3d/Assets/Test.cs
@@ -19,24 +19,37 @@ namespace DisruptorUnity3d
         private Thread _consumerThread;
         private bool _printed = false;
 
+        private int numberToEnqueue;
+
         public void Start()
         {
             Debug.Log("Started Test");
             _consumerThread = new Thread(() =>
             {
                 Debug.Log("Started consumer");
+                int expectedNumber = 0;
+                int previousNumber = 0;
                 for (long i = 0; i < Count; )
                 {
                     int val;
                     var dequeued = Queue.TryDequeue(out val);
                     if (dequeued)
+                    {
+                        if (expectedNumber != val)
+                            Debug.Log("wrong value " + val + " ,correct: " + i + " ,previous: " + previousNumber);
+                        previousNumber = val;
+                        expectedNumber++;
                         ++i;
+                    }
+                        
                 }
                 Debug.Log(string.Format("Consumer done {0}", sw.Elapsed));
             });
             _consumerThread.Start();
             sw.Start();
         }
+
+        
 
         // Update is called once per frame
         public void Update()
@@ -52,7 +65,7 @@ namespace DisruptorUnity3d
             {
                 for (long i = 0; i < BatchSize && _queued < Count; ++i)
                 {
-                    Queue.Enqueue(Rng.Next());
+                    Queue.Enqueue(numberToEnqueue++);
                     ++_queued;
                 }
             }


### PR DESCRIPTION
The Memory Barriers used in RingBuffer do not prevent reordering of read and write instructions when accessing _entries and the producer cursor. This could have an effect that the consumer reads a value from _entries before it gets actually updated, thus returning an older value.

This pull request makes sure that the producer writes the new value in `_entries`and then updates the producer cursor (to signal that the data are ready to be used). The consumer first reads the producer cursor to make sure that the data are ready and **then** reads the actual data stored in `_entries` to make sure it reads the latest value.

The updated benchmark script adds increasing numbers. Thus, when dequeuing items, we can check their value with the expected one.

Please read the corresponding issue: https://github.com/dave-hillier/disruptor-unity3d/issues/5
