### PR TITLE
Bounds safety in CopyTo

### DIFF
--- a/DisruptorUnity3d/Assets/ConcurrentQueue.cs
+++ b/DisruptorUnity3d/Assets/ConcurrentQueue.cs
@@ -187,10 +187,9 @@ namespace System.Threading.Collections
         public void CopyTo(T[] dest, int index)
         {
             IEnumerator<T> e = InternalGetEnumerator();
-            int i = index;
-            while (e.MoveNext())
+            for (int i = index; i < dest.Length && e.MoveNext(); ++i)
             {
-                dest[i++] = e.Current;
+                dest[i] = e.Current;
             }
         }
 


### PR DESCRIPTION
CopyTo is used internally by ToArray.

Consider the following:

T0: ToArray is called. An array of size n, where n == count, is allocated, and passed to CopyTo to fill
T1: An element is enqueued, count is increased by one
T2: CopyTo walks off the end of the array, throwing an IndexOutOfRangeException

An alternative solution would be to leave CopyTo alone and simply delete .ToArray(), relying on the LINQ extension to provide proper support.